### PR TITLE
Update IBM and Infineon

### DIFF
--- a/sites/ibm.js
+++ b/sites/ibm.js
@@ -14,12 +14,30 @@ const getJobs = async () => {
 
   const data = {
     appId: "careers",
-    scopes: ["careers", "careers2"],
-    query: { bool: { must: [] } },
-    post_filter: { term: { field_keyword_05: "Romania" } },
+    scopes: ["careers2"],
+    query: {
+      bool: {
+        must: [
+          {
+            simple_query_string: {
+              query: "Romania",
+              fields: [
+                "keywords^1",
+                "body^1",
+                "url^2",
+                "description^2",
+                "h1s_content^2",
+                "title^3",
+                "field_text_01",
+              ],
+            },
+          },
+        ],
+      },
+    },
     aggs: {
       field_keyword_172: {
-        filter: { term: { field_keyword_05: "Romania" } },
+        filter: { match_all: {} },
         aggs: {
           field_keyword_17: { terms: { field: "field_keyword_17", size: 6 } },
           field_keyword_17_count: {
@@ -28,7 +46,7 @@ const getJobs = async () => {
         },
       },
       field_keyword_083: {
-        filter: { term: { field_keyword_05: "Romania" } },
+        filter: { match_all: {} },
         aggs: {
           field_keyword_08: { terms: { field: "field_keyword_08", size: 6 } },
           field_keyword_08_count: {
@@ -37,7 +55,7 @@ const getJobs = async () => {
         },
       },
       field_keyword_184: {
-        filter: { term: { field_keyword_05: "Romania" } },
+        filter: { match_all: {} },
         aggs: {
           field_keyword_18: { terms: { field: "field_keyword_18", size: 6 } },
           field_keyword_18_count: {
@@ -57,11 +75,11 @@ const getJobs = async () => {
         },
       },
     },
-    size: 100,
-    sort: [{ dcdate: "desc" }, { _score: "desc" }],
+    size: 30,
+    sort: [{ _score: "desc" }, { pageviews: "desc" }],
     lang: "zz",
     localeSelector: {},
-    sm: { query: "", lang: "zz" },
+    sm: { query: "Romania", lang: "zz" },
     _source: [
       "_id",
       "title",

--- a/sites/infineon.js
+++ b/sites/infineon.js
@@ -1,5 +1,6 @@
 const { translate_city } = require("../utils.js");
 const {
+  Scraper,
   postApiPeViitor,
   generateJob,
   getParams,
@@ -9,61 +10,65 @@ const { Counties } = require("../getTownAndCounty.js");
 const _counties = new Counties();
 
 const getJobs = async () => {
-  const url = "https://www.infineon.com/search/jobs/jobs";
-  const body = "term=&offset=0&max_results=100&lang=en&country=Romania";
+  let start = 0;
+  const url = `https://jobs.infineon.com/api/apply/v2/jobs?domain=infineon.com&start=0&num=10&location=Romania&pid=563808958979269&domain=infineon.com&sort_by=relevance&triggerGoButton=true`;
 
-  const res = await fetch(url, {
-    method: "POST",
-    body: body,
-    headers: {
-      authority: "www.infineon.com",
-      accept: "application/json, text/javascript, */*; q=0.01",
-      "accept-language":
-        "ro-RO,ro;q=0.9,en-US;q=0.8,en;q=0.7,de;q=0.6,fr;q=0.5,it;q=0.4,pt;q=0.3,tr;q=0.2,es;q=0.1,pl;q=0.1,la;q=0.1",
-      "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-      cookie:
-        "cookie_consent_1=false; cookie_consent_version=release_2021-09; SESSION=d3d383eb-b610-436d-99c0-07120376d4b0; OptanonAlertBoxClosed=2023-07-18T06:08:47.477Z; OptanonConsent=isGpcEnabled=0&datestamp=Tue+Jul+18+2023+09%3A19%3A39+GMT%2B0300+(Eastern+European+Summer+Time)&version=202301.2.0&isIABGlobal=false&hosts=&consentId=c0cf95da-c208-4697-9a67-b992d325108a&interactionCount=1&landingPath=NotLandingPage&groups=C0001%3A1%2CC0002%3A0&geolocation=RO%3BB&AwaitingReconsent=false",
-      dnt: "1",
-      origin: "https://www.infineon.com",
-      referer: " https://www.infineon.com/cms/en/careers/jobsearch/jobsearch/",
-      "sec-ch-ua":
-        '"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"',
-      "sec-ch-ua-mobile": "?0",
-      "sec-ch-ua-platform": '"Windows"',
-      "sec-fetch-dest": "empty",
-      "sec-fetch-mode": "cors",
-      "sec-fetch-site": "same-origin",
-      "user-agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
-      "x-requested-with": "XMLHttpRequest",
-    },
-  }).then((response) => response.json());
+  let scraper = new Scraper(url);
+  let res = await scraper.get_soup("JSON");
 
   const jobs = [];
 
-  const items = res.pages.items;
+  let items = res.positions;
+  while (items && items.length > 0) {
+    for (const job of items) {
+      const location = job.location.split(" ");
+      if (location[location.length - 1].includes("Romania")) {
+        const job_title = job.name;
+        const job_link = job.canonicalPositionUrl;
+        const remote = job.work_location_option.replace("onsite", "on-site");
+        const locations = job.locations;
+        const cities = [];
+        let counties = [];
+        for (let i = 0; i < locations.length; i++) {
+          if (locations[i].includes("Romania")) {
+            const city = translate_city(locations[i].split(" ")[0]);
+            const { city: c, county: co } = await _counties.getCounties(city);
+            if (c) {
+              cities.push(c);
+              counties = [...new Set([...counties, ...co])];
+            }
+            continue;
+          }
+        }
 
-  for (const job of items) {
-    const job_title = job.title;
-    const job_link = "https://www.infineon.com" + job.detail_page_url;
-    const city = translate_city(job.location[0]);
+        const job_element = generateJob(
+          job_title,
+          job_link,
+          "Romania",
+          cities,
+          counties,
+          remote
+        );
 
-    const { city: c, county: co } = await _counties.getCounties(city);
-
-    const job_element = generateJob(job_title, job_link, "Romania", c, co);
-
-    jobs.push(job_element);
+        jobs.push(job_element);
+      }
+    }
+    start += 10;
+    const new_url = url.split("&start=")[0] + `&start=${start}`;
+    scraper = new Scraper(new_url);
+    res = await scraper.get_soup("JSON");
+    items = res.positions;
   }
-
   return jobs;
 };
 
 const run = async () => {
   const company = "Infineon";
-  const logo = "https://www.infineon.com/frontend/release_2023-06-1/dist/resources/img/logo-desktop-en.png";
+  const logo =
+    "https://www.infineon.com/frontend/release_2023-06-1/dist/resources/img/logo-desktop-en.png";
   const jobs = await getJobs();
-  const params = getParams(company, logo);
-  postApiPeViitor(jobs, params);
+    const params = getParams(company, logo);
+    postApiPeViitor(jobs, params);
 };
 
 if (require.main === module) {


### PR DESCRIPTION
This pull request updates job scraping logic for both the IBM and Infineon job sites to improve accuracy and data quality. The IBM job scraper now uses a more targeted search and adjusts result sorting and aggregation, while the Infineon scraper is refactored to use a new API and better handles job locations, supporting pagination and improved city/county extraction.

**IBM Job Scraper Improvements:**

* Changed the search query to use `simple_query_string` targeting "Romania" in multiple fields, and removed the post-filter and the "careers" scope for more accurate filtering.
* Updated aggregation filters to use `match_all` instead of filtering by Romania, broadening the aggregation results. [[1]](diffhunk://#diff-123030791044693f7f1f202fc169090a8dc6e0341103dbc55ee1a3bc1a3068c7L17-R40) [[2]](diffhunk://#diff-123030791044693f7f1f202fc169090a8dc6e0341103dbc55ee1a3bc1a3068c7L31-R49) [[3]](diffhunk://#diff-123030791044693f7f1f202fc169090a8dc6e0341103dbc55ee1a3bc1a3068c7L40-R58)
* Reduced the number of jobs fetched per request from 100 to 30, changed sorting to prioritize relevance and pageviews, and set the search query for the `sm` parameter to "Romania".

**Infineon Job Scraper Refactor:**

* Replaced the old POST-based scraping logic with a new API endpoint and switched to using the `Scraper` utility for fetching jobs. [[1]](diffhunk://#diff-d72280bc0cfaea6da2833fcae0d1eb33d266275df79bef6f21db2735bb0a5b16R3) [[2]](diffhunk://#diff-d72280bc0cfaea6da2833fcae0d1eb33d266275df79bef6f21db2735bb0a5b16L12-R68)
* Added support for paginated fetching by iterating through results in batches of 10, ensuring all jobs are retrieved.
* Improved job location extraction by parsing multiple locations, translating cities, and collecting unique counties, as well as handling remote/on-site work options.