### PR TITLE
Update Qualcom

### DIFF
--- a/sites/qualcomm.js
+++ b/sites/qualcomm.js
@@ -11,30 +11,29 @@ const _counties = new Counties();
 
 const getJobs = async () => {
   const url =
-    "https://prod-search-api.jobsyn.org/api/v1/solr/search?location=Romania&page=1";
+    "https://careers.qualcomm.com/api/apply/v2/jobs?domain=qualcomm.com&profile=&query=romania&domain=qualcomm.com&sort_by=relevance";
 
   const scraper = new Scraper(url);
-  scraper.config.headers = {
-    "Content-Type": "application/json",
-    Accept: "application/json",
-    "x-origin": "https://qualcomm.dejobs.org",
-    "User-Agent": "Mozilla/5.0",
-  };
   const jobs = [];
 
   const res = await scraper.get_soup("JSON");
 
-  const items = res.jobs;
+  const items = res.positions;
 
   for (const item of items) {
-    const job_title = item.title_exact;
-    const job_link = "https://qualcomm.dejobs.org/" + item.guid;
-    const location = translate_city(item.city_exact);
-    const { city: c, county: co } = await _counties.getCounties(location);
+    const country = item.location.split(", ").pop();
 
-    const job = generateJob(job_title, job_link, "Romania", c, co);
+    if (country.toLowerCase() !== "romania") continue;
+
+    const job_title = item.name;
+    const job_link = item.canonicalPositionUrl;
+    const city = translate_city(item.location.split(", ")[0].trim());
+    const county = (await _counties.getCounties(city)).county;
+
+    const job = generateJob(job_title, job_link, city, county);
     jobs.push(job);
   }
+
   return jobs;
 };
 


### PR DESCRIPTION
This pull request updates the job scraping logic for the Qualcomm site to use a new API endpoint and adapt to the updated response structure. The main focus is on ensuring only jobs in Romania are processed and on extracting job details from the new data format.

**API integration and data extraction updates:**

* Switched the jobs API endpoint from the old `jobsyn.org` URL to the new `careers.qualcomm.com` endpoint, reflecting changes in the source site.
* Updated the parsing logic to use the `positions` array instead of `jobs`, and adapted field extraction to the new API response structure (`name`, `canonicalPositionUrl`, and `location`).

**Filtering and data handling improvements:**

* Added a filter to process only jobs where the country is Romania, improving result accuracy.
* Changed city and county extraction logic to match the new data format, ensuring correct location assignment for each job.