### PR TITLE
Fixed github workflows

### DIFF
--- a/.github/workflows/runScrapers.yml
+++ b/.github/workflows/runScrapers.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'peviitor-ro/scrapers.js'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request introduces a small but important change to the GitHub Actions workflow configuration. The workflow will now only run if the repository is `peviitor-ro/scrapers.js`, preventing unnecessary workflow executions in forks or other repositories.

* Added a conditional (`if: github.repository == 'peviitor-ro/scrapers.js'`) to the `build` job in `.github/workflows/runScrapers.yml` to restrict workflow runs to the main repository.