### PR TITLE
refactor: enhance job location handling in Unilever scraper with city…

### DIFF
--- a/sites/unilever.js
+++ b/sites/unilever.js
@@ -1,9 +1,13 @@
+const { translate_city } = require("../utils.js");
 const {
   Scraper,
   postApiPeViitor,
   generateJob,
   getParams,
 } = require("peviitor_jsscraper");
+const { Counties } = require("../getTownAndCounty.js");
+
+const _counties = new Counties();
 
 const URL =
   "https://careers.unilever.com/search-jobs/results?ActiveFacetID=798549&RecordsPerPage=1000&Distance=50&RadiusUnitType=0&Location=Romania&ShowRadius=False&IsPagination=False&FacetType=0&FacetFilters%5B0%5D.ID=798549&FacetFilters%5B0%5D.FacetType=2&FacetFilters%5B0%5D.Count=15&FacetFilters%5B0%5D.Display=Romania&FacetFilters%5B0%5D.IsApplied=true&SearchResultsModuleName=Search+Results&SearchFiltersModuleName=Search+Filters&SortCriteria=0&SortDirection=0&SearchType=1&OrganizationIds=34155&ResultsType=0";
@@ -34,12 +38,16 @@ const getJobs = async () => {
     const job_link = `https://careers.unilever.com${match[1]}`;
     const job_title = match[2].replace(/<[^>]+>/g, "").trim();
     const location = match[3].replace(/<[^>]+>/g, "").trim();
+    const city = translate_city(location.split(",")[0].trim());
+    const { city: c, county } = await _counties.getCounties(city);
 
-    if (!location.toLowerCase().includes("romania")) {
-      continue;
-    }
-
-    jobs.push(generateJob(job_title, job_link, "Romania"));
+    jobs.push(generateJob(
+      job_title,
+      job_link,
+      "Romania",
+      c || city,
+      county || [],
+    ));
   }
 
   return jobs;


### PR DESCRIPTION
This pull request updates the `sites/unilever.js` scraper to improve how job location data is processed and stored. The main changes enhance city and county extraction for each job, making the data more structured and accurate.

**Location data extraction improvements:**

* Added the `translate_city` utility and the `Counties` class to help standardize and enrich city and county information from job locations.
* Updated the job parsing logic to:
  - Extract the city name from the job location string and translate it.
  - Use the `getCounties` method to determine the associated county.
  - Store both the translated city and county in the generated job data, instead of just the country.
* Removed the previous logic that filtered out jobs not explicitly mentioning "Romania" in the location, ensuring all jobs from the feed are processed.… translation and county retrieval